### PR TITLE
Fix registration photo upload with multipart form data

### DIFF
--- a/client/src/Store/Api/registrationApi.ts
+++ b/client/src/Store/Api/registrationApi.ts
@@ -22,7 +22,6 @@ const baseQuery = fetchBaseQuery({
   baseUrl: "https://marma-official-server.onrender.com/api",
   prepareHeaders: (headers, { getState }) => {
     const token = (getState() as RootState).auth.token;
-    headers.set('Content-Type', 'application/json');
     if (token) {
       headers.set('Authorization', `Bearer ${token}`);
     }
@@ -44,7 +43,7 @@ export const registrationApi = createApi({
      * @param registrationData - Complete registration form data
      * @returns Created registration with generated IDs
      */
-    createRegistration: builder.mutation<ApiResponse<Registration>, CreateRegistrationRequest>({
+    createRegistration: builder.mutation<ApiResponse<Registration>, FormData>({
       query: (registrationData) => ({
         url: '/registrations',
         method: 'POST',


### PR DESCRIPTION
## Summary
- Use `FormData` for registration requests and drop default JSON header
- Capture and preview uploaded photo locally before submission
- Build multipart form data and set form `encType` so server receives file in `req.file`

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm test` (client) *(fails: Missing script "test")*
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b83e1c812883268b071ec6e0392ee7