### PR TITLE
feat: implement admin auth routes and server integration

### DIFF
--- a/Server/Controller/authController.js
+++ b/Server/Controller/authController.js
@@ -271,7 +271,26 @@ export const changePassword = async (req, res) => {
  */
 export const refreshToken = async (req, res) => {
   try {
-    const user = await User.findByPk(req.user.id, {
+    const { refreshToken } = req.body;
+
+    if (!refreshToken) {
+      return res.status(400).json({
+        success: false,
+        message: 'Refresh token is required'
+      });
+    }
+
+    let decoded;
+    try {
+      decoded = jwt.verify(refreshToken, process.env.JWT_SECRET || 'your-secret-key', { ignoreExpiration: true });
+    } catch (err) {
+      return res.status(401).json({
+        success: false,
+        message: 'Invalid token'
+      });
+    }
+
+    const user = await User.findByPk(decoded.id, {
       attributes: { exclude: ['password'] }
     });
 
@@ -300,4 +319,14 @@ export const refreshToken = async (req, res) => {
       errors: [error.message]
     });
   }
+};
+
+/**
+ * Logout user
+ */
+export const logout = (req, res) => {
+  return res.json({
+    success: true,
+    message: 'Logged out successfully'
+  });
 };

--- a/Server/Router/authRoutes.js
+++ b/Server/Router/authRoutes.js
@@ -6,43 +6,47 @@ import {
   getProfile,
   updateProfile,
   changePassword,
-  refreshToken
+  refreshToken,
+  logout
 } from '../Controller/authController.js';
 import { authenticateToken, authorizeRoles } from '../middleware/auth.js';
 
 const authRouter = express.Router();
 
-// Login validation
-// const loginValidation = [
-//   body('email').isEmail().withMessage('Valid email is required'),
-//   body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters')
-// ];
+// Validation middleware
+const loginValidation = [
+  body('email').isEmail().withMessage('Valid email is required'),
+  body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters')
+];
 
-// Create admin validation
-// const createAdminValidation = [
-//   body('email').isEmail().withMessage('Valid email is required'),
-//   body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters'),
-//   body('firstName').optional().trim().isLength({ min: 1 }).withMessage('First name is required'),
-//   body('lastName').optional().trim().isLength({ min: 1 }).withMessage('Last name is required'),
-//   body('role').optional().isIn(['admin', 'super_admin']).withMessage('Invalid role')
-// ];
+const createAdminValidation = [
+  body('email').isEmail().withMessage('Valid email is required'),
+  body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters'),
+  body('firstName').optional().trim().isLength({ min: 1 }).withMessage('First name is required'),
+  body('lastName').optional().trim().isLength({ min: 1 }).withMessage('Last name is required'),
+  body('role').optional().isIn(['admin', 'super_admin']).withMessage('Invalid role')
+];
 
-// Change password validation
-// const changePasswordValidation = [
-//   body('currentPassword').notEmpty().withMessage('Current password is required'),
-//   body('newPassword').isLength({ min: 6 }).withMessage('New password must be at least 6 characters')
-// ];
+const changePasswordValidation = [
+  body('currentPassword').notEmpty().withMessage('Current password is required'),
+  body('newPassword').isLength({ min: 6 }).withMessage('New password must be at least 6 characters')
+];
 
 // Public routes
-// authRouter.post('/login', loginValidation, login);
+authRouter.post('/login', loginValidation, login);
+authRouter.post('/refresh', refreshToken);
 
 // Protected routes
-// authRouter.get('/profile', authenticateToken, getProfile);
-// authRouter.put('/profile', authenticateToken, updateProfile);
-// authRouter.post('/change-password', authenticateToken, changePasswordValidation, changePassword);
-// authRouter.post('/refresh', authenticateToken, refreshToken);
+authRouter.post('/logout', authenticateToken, logout);
+authRouter.get('/me', authenticateToken, getProfile);
+authRouter.put('/profile', authenticateToken, updateProfile);
+authRouter.put('/change-password', authenticateToken, changePasswordValidation, changePassword);
+authRouter.get('/verify', authenticateToken, (req, res) => {
+  res.json({ success: true, data: { valid: true } });
+});
 
 // Super admin only routes
-// authRouter.post('/create-admin', authenticateToken, authorizeRoles('super_admin'), createAdminValidation, createAdmin);
+authRouter.post('/create-admin', authenticateToken, authorizeRoles('super_admin'), createAdminValidation, createAdmin);
 
 export default authRouter;
+

--- a/client/src/Store/Api/registrationApi.ts
+++ b/client/src/Store/Api/registrationApi.ts
@@ -19,7 +19,7 @@ import type {
 
 // Base query with authentication
 const baseQuery = fetchBaseQuery({
-  baseUrl: "https://marma-official-server.onrender.com/api",
+  baseUrl: import.meta.env.VITE_API_URL || 'https://marma-official-server.onrender.com/api',
   prepareHeaders: (headers, { getState }) => {
     const token = (getState() as RootState).auth.token;
     if (token) {


### PR DESCRIPTION
## Summary
- add express auth routes for login, logout, profile, and admin creation
- support token refresh using body-provided token and add logout handler
- configure client registration API to use environment-based server URL

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm run lint` (client) *(fails: Cannot read properties of undefined reading 'allowShortCircuit')*

------
https://chatgpt.com/codex/tasks/task_e_68b84804f5bc832683344a8f8e0a4921