### PR TITLE
Fix registrations listing endpoint

### DIFF
--- a/Server/Router/registrationRoutes.js
+++ b/Server/Router/registrationRoutes.js
@@ -56,7 +56,8 @@ registrationRouter.get('/country/:country', authenticateToken, getRegistrationsB
 
 // Main routes
 registrationRouter.post('/', uploadPhoto, handleUploadError, registrationValidation, createRegistration);
-registrationRouter.get('/all', authenticateToken, getRegistrations);
+// Get all registrations
+registrationRouter.get('/', authenticateToken, getRegistrations);
 
 // ID-based routes (must be last)
 registrationRouter.get('/:id', authenticateToken, getRegistrationById);


### PR DESCRIPTION
## Summary
- correct registration router path to serve `/api/registrations`

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b854b09c6083268d2a5a8c79e81ac8